### PR TITLE
fix: remove infinite staletime on tables

### DIFF
--- a/packages/frontend/src/components/manage/age/AgeTable.tsx
+++ b/packages/frontend/src/components/manage/age/AgeTable.tsx
@@ -34,23 +34,17 @@ const AgeTable: FunctionComponent = () => {
 
   const [dialogAge, setDialogAge] = useState<AgeExtended | null>(null);
 
-  const { data, fetchNextPage, hasNextPage, refetch } = useApiInfiniteQuery(
-    {
-      path: "/ages",
-      queryParams: {
-        q: query,
-        pageSize: 10,
-        orderBy,
-        sortOrder,
-        extended: true,
-      },
-      schema: getAgesExtendedResponse,
+  const { data, fetchNextPage, hasNextPage, refetch } = useApiInfiniteQuery({
+    path: "/ages",
+    queryParams: {
+      q: query,
+      pageSize: 10,
+      orderBy,
+      sortOrder,
+      extended: true,
     },
-    {
-      staleTime: Infinity,
-      refetchOnMount: "always",
-    }
-  );
+    schema: getAgesExtendedResponse,
+  });
 
   const { mutate } = useApiMutation(
     { method: "DELETE" },

--- a/packages/frontend/src/components/manage/classe/ClasseTable.tsx
+++ b/packages/frontend/src/components/manage/classe/ClasseTable.tsx
@@ -36,23 +36,17 @@ const ClasseTable: FunctionComponent = () => {
 
   const [dialogClasse, setDialogClasse] = useState<SpeciesClassExtended | null>(null);
 
-  const { data, fetchNextPage, hasNextPage, refetch } = useApiInfiniteQuery(
-    {
-      path: "/classes",
-      queryParams: {
-        q: query,
-        pageSize: 10,
-        orderBy,
-        sortOrder,
-        extended: true,
-      },
-      schema: getClassesExtendedResponse,
+  const { data, fetchNextPage, hasNextPage, refetch } = useApiInfiniteQuery({
+    path: "/classes",
+    queryParams: {
+      q: query,
+      pageSize: 10,
+      orderBy,
+      sortOrder,
+      extended: true,
     },
-    {
-      staleTime: Infinity,
-      refetchOnMount: "always",
-    }
-  );
+    schema: getClassesExtendedResponse,
+  });
 
   const { mutate } = useApiMutation(
     { method: "DELETE" },

--- a/packages/frontend/src/components/manage/commune/CommuneTable.tsx
+++ b/packages/frontend/src/components/manage/commune/CommuneTable.tsx
@@ -44,23 +44,17 @@ const CommuneTable: FunctionComponent = () => {
 
   const [dialogCommune, setDialogCommune] = useState<TownExtended | null>(null);
 
-  const { data, fetchNextPage, hasNextPage, refetch } = useApiInfiniteQuery(
-    {
-      path: "/towns",
-      queryParams: {
-        q: query,
-        pageSize: 10,
-        orderBy,
-        sortOrder,
-        extended: true,
-      },
-      schema: getTownsExtendedResponse,
+  const { data, fetchNextPage, hasNextPage, refetch } = useApiInfiniteQuery({
+    path: "/towns",
+    queryParams: {
+      q: query,
+      pageSize: 10,
+      orderBy,
+      sortOrder,
+      extended: true,
     },
-    {
-      staleTime: Infinity,
-      refetchOnMount: "always",
-    }
-  );
+    schema: getTownsExtendedResponse,
+  });
 
   const { mutate } = useApiMutation(
     { method: "DELETE" },

--- a/packages/frontend/src/components/manage/comportement/ComportementTable.tsx
+++ b/packages/frontend/src/components/manage/comportement/ComportementTable.tsx
@@ -40,23 +40,17 @@ const ComportementTable: FunctionComponent = () => {
 
   const [dialogComportement, setDialogComportement] = useState<BehaviorExtended | null>(null);
 
-  const { data, fetchNextPage, hasNextPage, refetch } = useApiInfiniteQuery(
-    {
-      path: "/behaviors",
-      queryParams: {
-        q: query,
-        pageSize: 10,
-        orderBy,
-        sortOrder,
-        extended: true,
-      },
-      schema: getBehaviorsExtendedResponse,
+  const { data, fetchNextPage, hasNextPage, refetch } = useApiInfiniteQuery({
+    path: "/behaviors",
+    queryParams: {
+      q: query,
+      pageSize: 10,
+      orderBy,
+      sortOrder,
+      extended: true,
     },
-    {
-      staleTime: Infinity,
-      refetchOnMount: "always",
-    }
-  );
+    schema: getBehaviorsExtendedResponse,
+  });
 
   const { mutate } = useApiMutation(
     { method: "DELETE" },

--- a/packages/frontend/src/components/manage/departement/DepartementTable.tsx
+++ b/packages/frontend/src/components/manage/departement/DepartementTable.tsx
@@ -40,23 +40,17 @@ const DepartementTable: FunctionComponent = () => {
 
   const [dialogDepartement, setDialogDepartement] = useState<DepartmentExtended | null>(null);
 
-  const { data, fetchNextPage, hasNextPage, refetch } = useApiInfiniteQuery(
-    {
-      path: "/departments",
-      queryParams: {
-        q: query,
-        pageSize: 10,
-        orderBy,
-        sortOrder,
-        extended: true,
-      },
-      schema: getDepartmentsExtendedResponse,
+  const { data, fetchNextPage, hasNextPage, refetch } = useApiInfiniteQuery({
+    path: "/departments",
+    queryParams: {
+      q: query,
+      pageSize: 10,
+      orderBy,
+      sortOrder,
+      extended: true,
     },
-    {
-      staleTime: Infinity,
-      refetchOnMount: "always",
-    }
-  );
+    schema: getDepartmentsExtendedResponse,
+  });
 
   const { mutate } = useApiMutation(
     { method: "DELETE" },

--- a/packages/frontend/src/components/manage/espece/EspeceTable.tsx
+++ b/packages/frontend/src/components/manage/espece/EspeceTable.tsx
@@ -44,23 +44,17 @@ const EspeceTable: FunctionComponent = () => {
 
   const [dialogEspece, setDialogEspece] = useState<SpeciesExtended | null>(null);
 
-  const { data, fetchNextPage, hasNextPage, refetch } = useApiInfiniteQuery(
-    {
-      path: "/species",
-      queryParams: {
-        q: query,
-        pageSize: 10,
-        orderBy,
-        sortOrder,
-        extended: true,
-      },
-      schema: getSpeciesExtendedResponse,
+  const { data, fetchNextPage, hasNextPage, refetch } = useApiInfiniteQuery({
+    path: "/species",
+    queryParams: {
+      q: query,
+      pageSize: 10,
+      orderBy,
+      sortOrder,
+      extended: true,
     },
-    {
-      staleTime: Infinity,
-      refetchOnMount: "always",
-    }
-  );
+    schema: getSpeciesExtendedResponse,
+  });
 
   const { mutate } = useApiMutation(
     { method: "DELETE" },

--- a/packages/frontend/src/components/manage/estimation-distance/EstimationDistanceTable.tsx
+++ b/packages/frontend/src/components/manage/estimation-distance/EstimationDistanceTable.tsx
@@ -45,10 +45,6 @@ const EstimationDistanceTable: FunctionComponent = () => {
         extended: true,
       },
       schema: getDistanceEstimatesExtendedResponse,
-    },
-    {
-      staleTime: Infinity,
-      refetchOnMount: "always",
     }
   );
 

--- a/packages/frontend/src/components/manage/estimation-nombre/EstimationNombreTable.tsx
+++ b/packages/frontend/src/components/manage/estimation-nombre/EstimationNombreTable.tsx
@@ -37,23 +37,17 @@ const EstimationNombreTable: FunctionComponent = () => {
 
   const [dialogEstimationNombre, setDialogEstimationNombre] = useState<NumberEstimateExtended | null>(null);
 
-  const { data, fetchNextPage, hasNextPage, refetch } = useApiInfiniteQuery(
-    {
-      path: "/number-estimates",
-      queryParams: {
-        q: query,
-        pageSize: 10,
-        orderBy,
-        sortOrder,
-        extended: true,
-      },
-      schema: getNumberEstimatesExtendedResponse,
+  const { data, fetchNextPage, hasNextPage, refetch } = useApiInfiniteQuery({
+    path: "/number-estimates",
+    queryParams: {
+      q: query,
+      pageSize: 10,
+      orderBy,
+      sortOrder,
+      extended: true,
     },
-    {
-      staleTime: Infinity,
-      refetchOnMount: "always",
-    }
-  );
+    schema: getNumberEstimatesExtendedResponse,
+  });
 
   const { mutate } = useApiMutation(
     { method: "DELETE" },

--- a/packages/frontend/src/components/manage/lieu-dit/LieuDitTable.tsx
+++ b/packages/frontend/src/components/manage/lieu-dit/LieuDitTable.tsx
@@ -56,23 +56,17 @@ const LieuDitTable: FunctionComponent = () => {
 
   const [dialogLieuDit, setDialogLieuDit] = useState<LocalityExtended | null>(null);
 
-  const { data, fetchNextPage, hasNextPage, refetch } = useApiInfiniteQuery(
-    {
-      path: "/localities",
-      queryParams: {
-        q: query,
-        pageSize: 10,
-        orderBy,
-        sortOrder,
-        extended: true,
-      },
-      schema: getLocalitiesExtendedResponse,
+  const { data, fetchNextPage, hasNextPage, refetch } = useApiInfiniteQuery({
+    path: "/localities",
+    queryParams: {
+      q: query,
+      pageSize: 10,
+      orderBy,
+      sortOrder,
+      extended: true,
     },
-    {
-      staleTime: Infinity,
-      refetchOnMount: "always",
-    }
-  );
+    schema: getLocalitiesExtendedResponse,
+  });
 
   const { mutate } = useApiMutation(
     { method: "DELETE" },

--- a/packages/frontend/src/components/manage/meteo/MeteoTable.tsx
+++ b/packages/frontend/src/components/manage/meteo/MeteoTable.tsx
@@ -34,23 +34,17 @@ const MeteoTable: FunctionComponent = () => {
 
   const [dialogMeteo, setDialogMeteo] = useState<WeatherExtended | null>(null);
 
-  const { data, fetchNextPage, hasNextPage, refetch } = useApiInfiniteQuery(
-    {
-      path: "/weathers",
-      queryParams: {
-        q: query,
-        pageSize: 10,
-        orderBy,
-        sortOrder,
-        extended: true,
-      },
-      schema: getWeathersExtendedResponse,
+  const { data, fetchNextPage, hasNextPage, refetch } = useApiInfiniteQuery({
+    path: "/weathers",
+    queryParams: {
+      q: query,
+      pageSize: 10,
+      orderBy,
+      sortOrder,
+      extended: true,
     },
-    {
-      staleTime: Infinity,
-      refetchOnMount: "always",
-    }
-  );
+    schema: getWeathersExtendedResponse,
+  });
 
   const { mutate } = useApiMutation(
     { method: "DELETE" },

--- a/packages/frontend/src/components/manage/milieu/MilieuTable.tsx
+++ b/packages/frontend/src/components/manage/milieu/MilieuTable.tsx
@@ -36,23 +36,17 @@ const MilieuTable: FunctionComponent = () => {
 
   const [dialogMilieu, setDialogMilieu] = useState<Environment | null>(null);
 
-  const { data, fetchNextPage, hasNextPage, refetch } = useApiInfiniteQuery(
-    {
-      path: "/environments",
-      queryParams: {
-        q: query,
-        pageSize: 10,
-        orderBy,
-        sortOrder,
-        extended: true,
-      },
-      schema: getEnvironmentsExtendedResponse,
+  const { data, fetchNextPage, hasNextPage, refetch } = useApiInfiniteQuery({
+    path: "/environments",
+    queryParams: {
+      q: query,
+      pageSize: 10,
+      orderBy,
+      sortOrder,
+      extended: true,
     },
-    {
-      staleTime: Infinity,
-      refetchOnMount: "always",
-    }
-  );
+    schema: getEnvironmentsExtendedResponse,
+  });
 
   const { mutate } = useApiMutation(
     { method: "DELETE" },

--- a/packages/frontend/src/components/manage/observateur/ObservateurTable.tsx
+++ b/packages/frontend/src/components/manage/observateur/ObservateurTable.tsx
@@ -34,23 +34,17 @@ const ObservateurTable: FunctionComponent = () => {
 
   const [dialogObservateur, setDialogObservateur] = useState<ObserverExtended | null>(null);
 
-  const { data, fetchNextPage, hasNextPage, refetch } = useApiInfiniteQuery(
-    {
-      path: "/observers",
-      queryParams: {
-        q: query,
-        pageSize: 10,
-        orderBy,
-        sortOrder,
-        extended: true,
-      },
-      schema: getObserversExtendedResponse,
+  const { data, fetchNextPage, hasNextPage, refetch } = useApiInfiniteQuery({
+    path: "/observers",
+    queryParams: {
+      q: query,
+      pageSize: 10,
+      orderBy,
+      sortOrder,
+      extended: true,
     },
-    {
-      staleTime: Infinity,
-      refetchOnMount: "always",
-    }
-  );
+    schema: getObserversExtendedResponse,
+  });
 
   const { mutate } = useApiMutation(
     { method: "DELETE" },

--- a/packages/frontend/src/components/manage/sexe/SexeTable.tsx
+++ b/packages/frontend/src/components/manage/sexe/SexeTable.tsx
@@ -34,23 +34,17 @@ const SexeTable: FunctionComponent = () => {
 
   const [dialogSexe, setDialogSexe] = useState<SexExtended | null>(null);
 
-  const { data, fetchNextPage, hasNextPage, refetch } = useApiInfiniteQuery(
-    {
-      path: "/sexes",
-      queryParams: {
-        q: query,
-        pageSize: 10,
-        orderBy,
-        sortOrder,
-        extended: true,
-      },
-      schema: getSexesExtendedResponse,
+  const { data, fetchNextPage, hasNextPage, refetch } = useApiInfiniteQuery({
+    path: "/sexes",
+    queryParams: {
+      q: query,
+      pageSize: 10,
+      orderBy,
+      sortOrder,
+      extended: true,
     },
-    {
-      staleTime: Infinity,
-      refetchOnMount: "always",
-    }
-  );
+    schema: getSexesExtendedResponse,
+  });
   const { mutate } = useApiMutation(
     { method: "DELETE" },
     {


### PR DESCRIPTION
When migrated from GraphQL, those settings were made on all tables.

I don't recall exactly why I did this, but my guess is that I was trying to be smart and avoid the refetch on focus done with devtools maybe?

I think that I thought at the time that this would be OK to consider table cache as "fresh" as for a single user, the only ways to have a change are either:
- deleting an element -> this was handled by a (buggy?) refetch
- updating or adding an element -> since it triggers currently a navigation, it works by "refetching" on mount.

However, this is a wrong solution:
- Relying on a navigation and remount is fragile, and is broken by default whenever migrating upsert via popover for example.
- Refetch the current query will not refetch other queries that should be updated too. For example, if I create "bbb" and filter by "bb", then delete "bbb", we currently refetch the query with "bb", but the same one without query should also be refetched. Currently it is not, and we see a "ghost" "bbb" when we remove the filter.

I guess that there's no need to be too smart on this, and we should rely on TK default mechanism that consider all data as stale.
Sure it will trigger some additional requests for which - most of the time - the result won't have changed, but that's too risky to handle it properly.
Should it become a performance issue, we should reevaluate smarter caching.