### PR TITLE
fix(entity): table not always refreshed on delete

### DIFF
--- a/packages/frontend/src/components/manage/age/AgeTable.tsx
+++ b/packages/frontend/src/components/manage/age/AgeTable.tsx
@@ -144,7 +144,7 @@ const AgeTable: FunctionComponent = () => {
           );
         })}
         enableScroll={hasNextPage}
-        onMoreRequested={() => fetchNextPage()}
+        onMoreRequested={fetchNextPage}
       />
       <DeletionConfirmationDialog
         open={!!dialogAge}

--- a/packages/frontend/src/components/manage/classe/ClasseTable.tsx
+++ b/packages/frontend/src/components/manage/classe/ClasseTable.tsx
@@ -147,7 +147,7 @@ const ClasseTable: FunctionComponent = () => {
           );
         })}
         enableScroll={hasNextPage}
-        onMoreRequested={() => fetchNextPage()}
+        onMoreRequested={fetchNextPage}
       />
       <DeletionConfirmationDialog
         open={!!dialogClasse}

--- a/packages/frontend/src/components/manage/commune/CommuneTable.tsx
+++ b/packages/frontend/src/components/manage/commune/CommuneTable.tsx
@@ -157,7 +157,7 @@ const CommuneTable: FunctionComponent = () => {
           );
         })}
         enableScroll={hasNextPage}
-        onMoreRequested={() => fetchNextPage()}
+        onMoreRequested={fetchNextPage}
       />
       <DeletionConfirmationDialog
         open={!!dialogCommune}

--- a/packages/frontend/src/components/manage/comportement/ComportementTable.tsx
+++ b/packages/frontend/src/components/manage/comportement/ComportementTable.tsx
@@ -152,7 +152,7 @@ const ComportementTable: FunctionComponent = () => {
           );
         })}
         enableScroll={hasNextPage}
-        onMoreRequested={() => fetchNextPage()}
+        onMoreRequested={fetchNextPage}
       />
       <DeletionConfirmationDialog
         open={!!dialogComportement}

--- a/packages/frontend/src/components/manage/departement/DepartementTable.tsx
+++ b/packages/frontend/src/components/manage/departement/DepartementTable.tsx
@@ -152,7 +152,7 @@ const DepartementTable: FunctionComponent = () => {
           );
         })}
         enableScroll={hasNextPage}
-        onMoreRequested={() => fetchNextPage()}
+        onMoreRequested={fetchNextPage}
       />
       <DeletionConfirmationDialog
         open={!!dialogDepartement}

--- a/packages/frontend/src/components/manage/espece/EspeceTable.tsx
+++ b/packages/frontend/src/components/manage/espece/EspeceTable.tsx
@@ -157,7 +157,7 @@ const EspeceTable: FunctionComponent = () => {
           );
         })}
         enableScroll={hasNextPage}
-        onMoreRequested={() => fetchNextPage()}
+        onMoreRequested={fetchNextPage}
       />
       <DeletionConfirmationDialog
         open={!!dialogEspece}

--- a/packages/frontend/src/components/manage/estimation-distance/EstimationDistanceTable.tsx
+++ b/packages/frontend/src/components/manage/estimation-distance/EstimationDistanceTable.tsx
@@ -139,7 +139,7 @@ const EstimationDistanceTable: FunctionComponent = () => {
             })}</Fragment>;
           })}
         enableScroll={hasNextPage}
-        onMoreRequested={() => fetchNextPage()}
+        onMoreRequested={fetchNextPage}
       />
       <DeletionConfirmationDialog
         open={!!dialogEstimationDistance}

--- a/packages/frontend/src/components/manage/estimation-nombre/EstimationNombreTable.tsx
+++ b/packages/frontend/src/components/manage/estimation-nombre/EstimationNombreTable.tsx
@@ -148,7 +148,7 @@ const EstimationNombreTable: FunctionComponent = () => {
           );
         })}
         enableScroll={hasNextPage}
-        onMoreRequested={() => fetchNextPage()}
+        onMoreRequested={fetchNextPage}
       />
       <DeletionConfirmationDialog
         open={!!dialogEstimationNombre}

--- a/packages/frontend/src/components/manage/lieu-dit/LieuDitTable.tsx
+++ b/packages/frontend/src/components/manage/lieu-dit/LieuDitTable.tsx
@@ -172,7 +172,7 @@ const LieuDitTable: FunctionComponent = () => {
           );
         })}
         enableScroll={hasNextPage}
-        onMoreRequested={() => fetchNextPage()}
+        onMoreRequested={fetchNextPage}
       />
       <DeletionConfirmationDialog
         open={!!dialogLieuDit}

--- a/packages/frontend/src/components/manage/meteo/MeteoTable.tsx
+++ b/packages/frontend/src/components/manage/meteo/MeteoTable.tsx
@@ -144,7 +144,7 @@ const MeteoTable: FunctionComponent = () => {
           );
         })}
         enableScroll={hasNextPage}
-        onMoreRequested={() => fetchNextPage()}
+        onMoreRequested={fetchNextPage}
       />
       <DeletionConfirmationDialog
         open={!!dialogMeteo}

--- a/packages/frontend/src/components/manage/milieu/MilieuTable.tsx
+++ b/packages/frontend/src/components/manage/milieu/MilieuTable.tsx
@@ -147,7 +147,7 @@ const MilieuTable: FunctionComponent = () => {
           );
         })}
         enableScroll={hasNextPage}
-        onMoreRequested={() => fetchNextPage()}
+        onMoreRequested={fetchNextPage}
       />
       <DeletionConfirmationDialog
         open={!!dialogMilieu}

--- a/packages/frontend/src/components/manage/observateur/ObservateurTable.tsx
+++ b/packages/frontend/src/components/manage/observateur/ObservateurTable.tsx
@@ -144,7 +144,7 @@ const ObservateurTable: FunctionComponent = () => {
           );
         })}
         enableScroll={hasNextPage}
-        onMoreRequested={() => fetchNextPage()}
+        onMoreRequested={fetchNextPage}
       />
       <DeletionConfirmationDialog
         open={!!dialogObservateur}

--- a/packages/frontend/src/components/manage/sexe/SexeTable.tsx
+++ b/packages/frontend/src/components/manage/sexe/SexeTable.tsx
@@ -143,7 +143,7 @@ const SexeTable: FunctionComponent = () => {
           );
         })}
         enableScroll={hasNextPage}
-        onMoreRequested={() => fetchNextPage()}
+        onMoreRequested={fetchNextPage}
       />
       <DeletionConfirmationDialog
         open={!!dialogSexe}

--- a/packages/frontend/src/components/search/search-entries-table/SearchEntriesTable.tsx
+++ b/packages/frontend/src/components/search/search-entries-table/SearchEntriesTable.tsx
@@ -138,7 +138,7 @@ const SearchEntriesTable: FunctionComponent = () => {
           );
         })}
         enableScroll={hasNextPage}
-        onMoreRequested={() => fetchNextPage()}
+        onMoreRequested={fetchNextPage}
       />
 
       <DeletionConfirmationDialog

--- a/packages/frontend/src/components/search/search-species-table/SearchSpeciesTable.tsx
+++ b/packages/frontend/src/components/search/search-species-table/SearchSpeciesTable.tsx
@@ -98,7 +98,7 @@ const SearchSpeciesTable: FunctionComponent = () => {
         );
       })}
       enableScroll={hasNextPage}
-      onMoreRequested={() => fetchNextPage()}
+      onMoreRequested={fetchNextPage}
     />
   );
 };


### PR DESCRIPTION
Probably solves #1266 .

Did not find exactly the meaning of it, however:
- As we pass an anonymous function that contains `fetchNextPage` , this is unstable on the `useEffect` of `InfiniteTable`.
- Passing this anonymous function that is different on each render might make Tanstack Query loses track of the use of the infinite query. That could explain the refresh issues.
- I mainly noticed the issue on localhost, which has strict mode, so that could explain it.

⚠️  Take care than when passing anonymous functions as `onXXX()`, they can be used in effects so it might have weird side effects. It's the second time I got bitten by this, and it's really tricky to investigate.