### PR TITLE
feat(entities): disable delete button whenever deletion will fail

### DIFF
--- a/packages/backend/src/controllers/localities-controller.ts
+++ b/packages/backend/src/controllers/localities-controller.ts
@@ -18,7 +18,7 @@ export const enrichedLocality = async (
   services: Services,
   locality: Locality,
   user: LoggedUser | null
-): Promise<Omit<LocalityExtended, "entriesCount">> => {
+): Promise<Omit<LocalityExtended, "inventoriesCount" | "entriesCount">> => {
   const town = await services.communeService.findCommuneOfLieuDitId(locality.id, user);
   const department = town ? await services.departementService.findDepartementOfCommuneId(town.id, user) : null;
 
@@ -76,12 +76,14 @@ const localitiesController: FastifyPluginCallback<{
           // TODO look to optimize this request
           const town = await communeService.findCommuneOfLieuDitId(localityData.id, req.user);
           const department = town ? await departementService.findDepartementOfCommuneId(town.id, req.user) : null;
+          const inventoriesCount = await lieuditService.getInventoriesCountByLocality(localityData.id, req.user);
           const entriesCount = await lieuditService.getDonneesCountByLieuDit(localityData.id, req.user);
           return {
             ...localityData,
             townCode: town?.code,
             townName: town?.nom,
             departmentCode: department?.code,
+            inventoriesCount,
             entriesCount,
           };
         })

--- a/packages/backend/src/controllers/observers-controller.ts
+++ b/packages/backend/src/controllers/observers-controller.ts
@@ -52,9 +52,11 @@ const observersController: FastifyPluginCallback<{
     if (extended) {
       data = await Promise.all(
         observersData.map(async (observerData) => {
+          const inventoriesCount = await observateurService.getInventoriesCountByObserver(observerData.id, req.user);
           const entriesCount = await observateurService.getDonneesCountByObservateur(observerData.id, req.user);
           return {
             ...observerData,
+            inventoriesCount,
             entriesCount,
           };
         })

--- a/packages/backend/src/repositories/inventaire/inventaire-repository.ts
+++ b/packages/backend/src/repositories/inventaire/inventaire-repository.ts
@@ -133,6 +133,32 @@ export const buildInventaireRepository = ({ slonik }: InventaireRepositoryDepend
     return slonik.oneFirst(query);
   };
 
+  const getCountByLocality = async (localityId: number): Promise<number> => {
+    const query = sql.type(countSchema)`
+      SELECT 
+        COUNT(*)
+      FROM
+        basenaturaliste.inventaire
+      WHERE
+        inventaire.lieudit_id = ${localityId}
+    `;
+
+    return slonik.oneFirst(query);
+  };
+
+  const getCountByObserver = async (observerId: number): Promise<number> => {
+    const query = sql.type(countSchema)`
+      SELECT 
+        COUNT(*)
+      FROM
+        basenaturaliste.inventaire
+      WHERE
+        inventaire.observateur_id = ${observerId}
+    `;
+
+    return slonik.oneFirst(query);
+  };
+
   const findInventaireByDonneeId = async (
     donneeId: number | undefined,
     transaction?: DatabaseTransactionConnection
@@ -301,6 +327,8 @@ export const buildInventaireRepository = ({ slonik }: InventaireRepositoryDepend
     findInventoryIndex,
     findInventaires,
     getCount,
+    getCountByLocality,
+    getCountByObserver,
     findExistingInventaire,
     createInventaire,
     updateInventaire,

--- a/packages/backend/src/services/entities/lieu-dit-service.ts
+++ b/packages/backend/src/services/entities/lieu-dit-service.ts
@@ -3,6 +3,7 @@ import { type Locality } from "@ou-ca/common/entities/locality";
 import { type Logger } from "pino";
 import { UniqueIntegrityConstraintViolationError } from "slonik";
 import { type DonneeRepository } from "../../repositories/donnee/donnee-repository.js";
+import { type InventaireRepository } from "../../repositories/inventaire/inventaire-repository.js";
 import {
   type LieuditCreateInput,
   type LieuditWithCommuneAndDepartementCode,
@@ -18,15 +19,26 @@ import { reshapeInputLieuditUpsertData, reshapeLocalityRepositoryToApi } from ".
 type LieuditServiceDependencies = {
   logger: Logger;
   lieuditRepository: LieuditRepository;
+  inventaireRepository: InventaireRepository;
   donneeRepository: DonneeRepository;
 };
 
-export const buildLieuditService = ({ lieuditRepository, donneeRepository }: LieuditServiceDependencies) => {
+export const buildLieuditService = ({
+  lieuditRepository,
+  inventaireRepository,
+  donneeRepository,
+}: LieuditServiceDependencies) => {
   const findLieuDit = async (id: number, loggedUser: LoggedUser | null): Promise<Locality | null> => {
     validateAuthorization(loggedUser);
 
     const locality = await lieuditRepository.findLieuditById(id);
     return reshapeLocalityRepositoryToApi(locality, loggedUser);
+  };
+
+  const getInventoriesCountByLocality = async (id: string, loggedUser: LoggedUser | null): Promise<number> => {
+    validateAuthorization(loggedUser);
+
+    return inventaireRepository.getCountByLocality(parseInt(id));
   };
 
   const getDonneesCountByLieuDit = async (id: string, loggedUser: LoggedUser | null): Promise<number> => {
@@ -176,6 +188,7 @@ export const buildLieuditService = ({ lieuditRepository, donneeRepository }: Lie
 
   return {
     findLieuDit,
+    getInventoriesCountByLocality,
     getDonneesCountByLieuDit,
     findLieuDitOfInventaireId,
     findAllLieuxDits,

--- a/packages/backend/src/services/entities/observateur-service.ts
+++ b/packages/backend/src/services/entities/observateur-service.ts
@@ -3,6 +3,7 @@ import { type Observer } from "@ou-ca/common/entities/observer";
 import { type Logger } from "pino";
 import { UniqueIntegrityConstraintViolationError } from "slonik";
 import { type DonneeRepository } from "../../repositories/donnee/donnee-repository.js";
+import { type InventaireRepository } from "../../repositories/inventaire/inventaire-repository.js";
 import { type ObservateurCreateInput } from "../../repositories/observateur/observateur-repository-types.js";
 import { type ObservateurRepository } from "../../repositories/observateur/observateur-repository.js";
 import { type LoggedUser } from "../../types/User.js";
@@ -13,12 +14,14 @@ import { enrichEntityWithEditableStatus, getSqlPagination } from "./entities-uti
 
 type ObservateurServiceDependencies = {
   logger: Logger;
+  inventaireRepository: InventaireRepository;
   observateurRepository: ObservateurRepository;
   donneeRepository: DonneeRepository;
 };
 
 export const buildObservateurService = ({
   observateurRepository,
+  inventaireRepository,
   donneeRepository,
 }: ObservateurServiceDependencies) => {
   const findObservateur = async (id: number, loggedUser: LoggedUser | null): Promise<Observer | null> => {
@@ -26,6 +29,12 @@ export const buildObservateurService = ({
 
     const observer = await observateurRepository.findObservateurById(id);
     return enrichEntityWithEditableStatus(observer, loggedUser);
+  };
+
+  const getInventoriesCountByObserver = async (id: string, loggedUser: LoggedUser | null): Promise<number> => {
+    validateAuthorization(loggedUser);
+
+    return inventaireRepository.getCountByObserver(parseInt(id));
   };
 
   const getDonneesCountByObservateur = async (id: string, loggedUser: LoggedUser | null): Promise<number> => {
@@ -190,6 +199,7 @@ export const buildObservateurService = ({
 
   return {
     findObservateur,
+    getInventoriesCountByObserver,
     getDonneesCountByObservateur,
     findObservateurOfInventaireId,
     findAssociesOfInventaireId,

--- a/packages/backend/src/services/services.ts
+++ b/packages/backend/src/services/services.ts
@@ -182,6 +182,7 @@ export const buildServices = async (config: Config): Promise<Services> => {
   const lieuditService = buildLieuditService({
     logger,
     lieuditRepository,
+    inventaireRepository,
     donneeRepository,
   });
 
@@ -200,6 +201,7 @@ export const buildServices = async (config: Config): Promise<Services> => {
   const observateurService = buildObservateurService({
     logger,
     observateurRepository,
+    inventaireRepository,
     donneeRepository,
   });
 

--- a/packages/common/src/entities/inventory.ts
+++ b/packages/common/src/entities/inventory.ts
@@ -20,7 +20,7 @@ export const inventorySchema = z.object({
 export type Inventory = z.infer<typeof inventorySchema>;
 
 export const inventoryExtendedSchema = inventorySchema.omit({ locality: true }).extend({
-  locality: localityExtendedSchema.omit({ entriesCount: true }),
+  locality: localityExtendedSchema.omit({ inventoriesCount: true, entriesCount: true }),
 });
 
 export type InventoryExtended = z.infer<typeof inventoryExtendedSchema>;

--- a/packages/common/src/entities/locality.ts
+++ b/packages/common/src/entities/locality.ts
@@ -15,6 +15,7 @@ export const localityExtendedSchema = localitySchema.extend({
   townCode: z.number(),
   townName: z.string(),
   departmentCode: z.string(),
+  inventoriesCount: z.number(),
   entriesCount: z.number(),
 });
 

--- a/packages/common/src/entities/observer.ts
+++ b/packages/common/src/entities/observer.ts
@@ -9,6 +9,7 @@ export const observerSchema = z.object({
 export type Observer = z.infer<typeof observerSchema>;
 
 export const observerExtendedSchema = observerSchema.extend({
+  inventoriesCount: z.number(),
   entriesCount: z.number(),
 });
 

--- a/packages/frontend/src/components/common/styled/IconButton.tsx
+++ b/packages/frontend/src/components/common/styled/IconButton.tsx
@@ -5,7 +5,7 @@ const IconButton: FunctionComponent<PropsWithChildren<ComponentPropsWithoutRef<"
   className,
   ...props
 }) => (
-  <div className="tooltip tooltip-bottom" data-tip={props["aria-label"]}>
+  <div className="tooltip tooltip-bottom" data-tip={!props.disabled ? props["aria-label"] : undefined}>
     <button type="button" className={`btn btn-circle btn-sm btn-ghost ${className ?? ""}`} {...props}>
       {children}
     </button>

--- a/packages/frontend/src/components/manage/age/AgeTable.tsx
+++ b/packages/frontend/src/components/manage/age/AgeTable.tsx
@@ -89,7 +89,8 @@ const AgeTable: FunctionComponent<AgeTableProps> = ({ onClickUpdateAge, onClickD
                     <td>{age.entriesCount}</td>
                     <td align="right" className="pr-6">
                       <TableCellActionButtons
-                        disabled={!age.editable}
+                        disabledEdit={!age.editable}
+                        disabledDelete={!age.editable || age.entriesCount > 0}
                         onEditClicked={() => onClickUpdateAge(age)}
                         onDeleteClicked={() => onClickDeleteAge(age)}
                       />

--- a/packages/frontend/src/components/manage/classe/ClasseTable.tsx
+++ b/packages/frontend/src/components/manage/classe/ClasseTable.tsx
@@ -92,7 +92,8 @@ const ClasseTable: FunctionComponent<ClasseTableProps> = ({ onClickUpdateSpecies
                     <td>{classe.entriesCount}</td>
                     <td align="right" className="pr-6">
                       <TableCellActionButtons
-                        disabled={!classe.editable}
+                        disabledEdit={!classe.editable}
+                        disabledDelete={!classe.editable || classe.speciesCount > 0}
                         onEditClicked={() => onClickUpdateSpeciesClass(classe)}
                         onDeleteClicked={() => onClickDeleteSpeciesClass(classe)}
                       />

--- a/packages/frontend/src/components/manage/common/TableCellActionButtons.tsx
+++ b/packages/frontend/src/components/manage/common/TableCellActionButtons.tsx
@@ -4,20 +4,21 @@ import { useTranslation } from "react-i18next";
 import IconButton from "../../common/styled/IconButton";
 
 type TableCellActionButtonsProps = {
-  disabled?: boolean;
+  disabledEdit?: boolean;
+  disabledDelete?: boolean;
   onEditClicked?: () => void;
   onDeleteClicked?: () => void;
 };
 
 const TableCellActionButtons: FunctionComponent<TableCellActionButtonsProps> = (props) => {
-  const { disabled, onEditClicked, onDeleteClicked } = props;
+  const { disabledEdit, disabledDelete, onEditClicked, onDeleteClicked } = props;
   const { t } = useTranslation();
 
   return (
     <>
       <IconButton
         className="mx-1 text-primary dark:text-white"
-        disabled={disabled}
+        disabled={disabledEdit}
         aria-label={t("aria-editButton")}
         onClick={onEditClicked}
       >
@@ -25,7 +26,7 @@ const TableCellActionButtons: FunctionComponent<TableCellActionButtonsProps> = (
       </IconButton>
       <IconButton
         className="mx-1 text-error"
-        disabled={disabled}
+        disabled={disabledDelete}
         aria-label={t("aria-deleteButton")}
         onClick={onDeleteClicked}
       >

--- a/packages/frontend/src/components/manage/commune/CommuneTable.tsx
+++ b/packages/frontend/src/components/manage/commune/CommuneTable.tsx
@@ -102,7 +102,8 @@ const CommuneTable: FunctionComponent<CommuneTableProps> = ({ onClickUpdateTown,
                     <td>{commune.entriesCount}</td>
                     <td align="right" className="pr-6">
                       <TableCellActionButtons
-                        disabled={!commune.editable}
+                        disabledEdit={!commune.editable}
+                        disabledDelete={!commune.editable || commune.localitiesCount > 0}
                         onEditClicked={() => onClickUpdateTown(commune)}
                         onDeleteClicked={() => onClickDeleteTown(commune)}
                       />

--- a/packages/frontend/src/components/manage/comportement/ComportementTable.tsx
+++ b/packages/frontend/src/components/manage/comportement/ComportementTable.tsx
@@ -100,7 +100,8 @@ const ComportementTable: FunctionComponent<ComportementTableProps> = ({
                     <td>{comportement.entriesCount}</td>
                     <td align="right" className="pr-6">
                       <TableCellActionButtons
-                        disabled={!comportement.editable}
+                        disabledEdit={!comportement.editable}
+                        disabledDelete={!comportement.editable}
                         onEditClicked={() => onClickUpdateBehavior(comportement)}
                         onDeleteClicked={() => onClickDeleteBehavior(comportement)}
                       />

--- a/packages/frontend/src/components/manage/departement/DepartementTable.tsx
+++ b/packages/frontend/src/components/manage/departement/DepartementTable.tsx
@@ -100,7 +100,8 @@ const DepartementTable: FunctionComponent<DepartementTableProps> = ({
                     <td>{departement.entriesCount}</td>
                     <td align="right" className="pr-6">
                       <TableCellActionButtons
-                        disabled={!departement.editable}
+                        disabledEdit={!departement.editable}
+                        disabledDelete={!departement.editable || departement.townsCount > 0}
                         onEditClicked={() => onClickUpdateDepartment(departement)}
                         onDeleteClicked={() => onClickDeleteDepartment(departement)}
                       />

--- a/packages/frontend/src/components/manage/espece/EspeceTable.tsx
+++ b/packages/frontend/src/components/manage/espece/EspeceTable.tsx
@@ -102,7 +102,8 @@ const EspeceTable: FunctionComponent<EspeceTableProps> = ({ onClickUpdateSpecies
                     <td>{espece.entriesCount}</td>
                     <td align="right" className="pr-6">
                       <TableCellActionButtons
-                        disabled={!espece.editable}
+                        disabledEdit={!espece.editable}
+                        disabledDelete={!espece.editable || espece.entriesCount > 0}
                         onEditClicked={() => onClickUpdateSpecies(espece)}
                         onDeleteClicked={() => onClickDeleteSpecies(espece)}
                       />

--- a/packages/frontend/src/components/manage/estimation-distance/EstimationDistanceTable.tsx
+++ b/packages/frontend/src/components/manage/estimation-distance/EstimationDistanceTable.tsx
@@ -86,7 +86,8 @@ const EstimationDistanceTable: FunctionComponent<EstimationDistanceTableProps> =
                   <td>{estimationDistance.entriesCount}</td>
                   <td align="right" className="pr-6">
                     <TableCellActionButtons
-                      disabled={!estimationDistance.editable}
+                      disabledEdit={!estimationDistance.editable}
+                      disabledDelete={!estimationDistance.editable || estimationDistance.entriesCount > 0}
                       onEditClicked={() => onClickUpdateDistanceEstimate(estimationDistance)}
                       onDeleteClicked={() => onClickDeleteDistanceEstimate(estimationDistance)}
                     />

--- a/packages/frontend/src/components/manage/estimation-nombre/EstimationNombreTable.tsx
+++ b/packages/frontend/src/components/manage/estimation-nombre/EstimationNombreTable.tsx
@@ -96,7 +96,8 @@ const EstimationNombreTable: FunctionComponent<EstimationNombreTableProps> = ({
                     <td>{estimationNombre.entriesCount}</td>
                     <td align="right" className="pr-6">
                       <TableCellActionButtons
-                        disabled={!estimationNombre.editable}
+                        disabledEdit={!estimationNombre.editable}
+                        disabledDelete={!estimationNombre.editable || estimationNombre.entriesCount > 0}
                         onEditClicked={() => onClickUpdateNumberEstimate(estimationNombre)}
                         onDeleteClicked={() => onClickDeleteNumberEstimate(estimationNombre)}
                       />

--- a/packages/frontend/src/components/manage/lieu-dit/LieuDitTable.tsx
+++ b/packages/frontend/src/components/manage/lieu-dit/LieuDitTable.tsx
@@ -117,7 +117,8 @@ const LieuDitTable: FunctionComponent<LieuDitTableProps> = ({ onClickUpdateLocal
                     <td>{lieuDit.entriesCount}</td>
                     <td align="right" className="pr-6">
                       <TableCellActionButtons
-                        disabled={!lieuDit.editable}
+                        disabledEdit={!lieuDit.editable}
+                        disabledDelete={!lieuDit.editable || lieuDit.inventoriesCount > 0}
                         onEditClicked={() => onClickUpdateLocality(lieuDit)}
                         onDeleteClicked={() => onClickDeleteLocality(lieuDit)}
                       />

--- a/packages/frontend/src/components/manage/meteo/MeteoTable.tsx
+++ b/packages/frontend/src/components/manage/meteo/MeteoTable.tsx
@@ -89,7 +89,8 @@ const MeteoTable: FunctionComponent<MeteoTableProps> = ({ onClickUpdateWeather, 
                     <td>{meteo.entriesCount}</td>
                     <td align="right" className="pr-6">
                       <TableCellActionButtons
-                        disabled={!meteo.editable}
+                        disabledEdit={!meteo.editable}
+                        disabledDelete={!meteo.editable}
                         onEditClicked={() => onClickUpdateWeather(meteo)}
                         onDeleteClicked={() => onClickDeleteWeather(meteo)}
                       />

--- a/packages/frontend/src/components/manage/milieu/MilieuTable.tsx
+++ b/packages/frontend/src/components/manage/milieu/MilieuTable.tsx
@@ -92,7 +92,8 @@ const MilieuTable: FunctionComponent<MilieuTableProps> = ({ onClickUpdateEnviron
                     <td>{milieu.entriesCount}</td>
                     <td align="right" className="pr-6">
                       <TableCellActionButtons
-                        disabled={!milieu.editable}
+                        disabledEdit={!milieu.editable}
+                        disabledDelete={!milieu.editable}
                         onEditClicked={() => onClickUpdateEnvironment(milieu)}
                         onDeleteClicked={() => onClickDeleteEnvironment(milieu)}
                       />

--- a/packages/frontend/src/components/manage/observateur/ObservateurTable.tsx
+++ b/packages/frontend/src/components/manage/observateur/ObservateurTable.tsx
@@ -92,7 +92,8 @@ const ObservateurTable: FunctionComponent<ObservateurTableProps> = ({
                     <td>{observateur.entriesCount}</td>
                     <td align="right" className="pr-6">
                       <TableCellActionButtons
-                        disabled={!observateur.editable}
+                        disabledEdit={!observateur.editable}
+                        disabledDelete={!observateur.editable || observateur.inventoriesCount > 0}
                         onEditClicked={() => onClickUpdateObserver(observateur)}
                         onDeleteClicked={() => onClickDeleteObserver(observateur)}
                       />

--- a/packages/frontend/src/components/manage/sexe/SexeTable.tsx
+++ b/packages/frontend/src/components/manage/sexe/SexeTable.tsx
@@ -89,7 +89,8 @@ const SexeTable: FunctionComponent<SexeTableProps> = ({ onClickUpdateSex, onClic
                     <td>{sexe?.entriesCount}</td>
                     <td align="right" className="pr-6">
                       <TableCellActionButtons
-                        disabled={!sexe.editable}
+                        disabledEdit={!sexe.editable}
+                        disabledDelete={!sexe.editable || sexe.entriesCount > 0}
                         onEditClicked={() => onClickUpdateSex(sexe)}
                         onDeleteClicked={() => onClickDeleteSex(sexe)}
                       />


### PR DESCRIPTION
Fixes weird behavior whenever an entity appears as can be deleted, but really can't because the entity is used as foreign key elsewhere.

The rationale is to do the check on frontend side, because:
- It's the quickest way
- Doing it on backend side could be _better_ but we would need a bigger overhaul that is not worth it. Even if the backend returns the info, it may not be accurate by the time the user clicks on the button anymore.
- We need to investigate if we want to keep the foreign keys as-is, so let's not lose time with this kind of edge case.

This PR also fixes the case where a button tooltip was displayed even though the underlying button was disabled, which is cumbersome.

resolves #1236 