### PR TITLE
feat: improve user session experience

### DIFF
--- a/packages/frontend/public/locales/fr/translation.json
+++ b/packages/frontend/public/locales/fr/translation.json
@@ -408,5 +408,9 @@
   "saveSettingsError": "Une erreur est survenue lors de la sauvegarde de vos préférences. Veuillez réessayer",
   "exportDatabaseButton": "Sauvegarde de la base",
   "importFromFile": "Import depuis un fichier",
-  "logout": "Déconnexion"
+  "logout": "Déconnexion",
+  "sessionExpired": {
+    "description": "Votre session utilisateur a expiré. Veuillez vous reconnecter.",
+    "reconnectButton": "Me reconnecter"
+  }
 }

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -35,7 +35,7 @@ const App: FunctionComponent<AppProps> = ({ config, router }) => {
     return {
       ...config.oidc,
       redirect_uri: `${window.location.protocol}//${window.location.host}/`,
-      scope: "openid email profile",
+      scope: "openid email profile offline_access",
       userStore: new WebStorageStateStore({ store: window.localStorage }),
     } satisfies UserManagerSettings;
   }, [config]);

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -1,10 +1,9 @@
 import { QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-import { type UserManagerSettings } from "oidc-client-ts";
+import { WebStorageStateStore, type UserManagerSettings } from "oidc-client-ts";
 import { Suspense, useEffect, useMemo, useState, type FunctionComponent } from "react";
 import { AuthProvider } from "react-oidc-context";
 import { RouterProvider, type createBrowserRouter } from "react-router-dom";
-import { AuthHandler } from "./components/AuthHandler";
 import { AppContext, DEFAULT_CONFIG } from "./contexts/AppContext";
 import { queryClient } from "./query/query-client";
 import loadAnalytics from "./services/load-analytics";
@@ -37,6 +36,8 @@ const App: FunctionComponent<AppProps> = ({ config, router }) => {
       ...config.oidc,
       redirect_uri: `${window.location.protocol}//${window.location.host}/`,
       scope: "openid email profile",
+      userStore: new WebStorageStateStore({ store: window.localStorage }),
+      automaticSilentRenew: false, // Disable renew as we don't use refresh tokens for now
     } satisfies UserManagerSettings;
   }, [config]);
 
@@ -50,13 +51,11 @@ const App: FunctionComponent<AppProps> = ({ config, router }) => {
       >
         <QueryClientProvider client={queryClient}>
           <ReactQueryDevtools />
-          <AuthHandler>
-            <div className="bg-base-100">
-              <Suspense fallback="">
-                <RouterProvider router={router} />
-              </Suspense>
-            </div>
-          </AuthHandler>
+          <div className="bg-base-100">
+            <Suspense fallback="">
+              <RouterProvider router={router} />
+            </Suspense>
+          </div>
         </QueryClientProvider>
       </AuthProvider>
     </AppContext.Provider>

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -37,7 +37,6 @@ const App: FunctionComponent<AppProps> = ({ config, router }) => {
       redirect_uri: `${window.location.protocol}//${window.location.host}/`,
       scope: "openid email profile",
       userStore: new WebStorageStateStore({ store: window.localStorage }),
-      automaticSilentRenew: false, // Disable renew as we don't use refresh tokens for now
     } satisfies UserManagerSettings;
   }, [config]);
 

--- a/packages/frontend/src/components/session-expired/SessionExpired.tsx
+++ b/packages/frontend/src/components/session-expired/SessionExpired.tsx
@@ -1,0 +1,27 @@
+import { type FunctionComponent } from "react";
+import { useTranslation } from "react-i18next";
+import { useAuth } from "react-oidc-context";
+
+const SessionExpired: FunctionComponent = () => {
+  const { t } = useTranslation();
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  const { removeUser } = useAuth();
+
+  const handleReconnect = async () => {
+    await removeUser();
+    window.location.replace("/");
+  };
+
+  return (
+    <div className="flex h-[100dvh] justify-center items-center">
+      <div className="flex flex-col gap-8 items-center">
+        <span className="text-xl text-primary">{t("sessionExpired.description")}</span>
+        <button type="button" className="btn btn-primary" onClick={handleReconnect}>
+          {t("sessionExpired.reconnectButton")}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default SessionExpired;

--- a/packages/frontend/src/router/routes.tsx
+++ b/packages/frontend/src/router/routes.tsx
@@ -1,4 +1,5 @@
 import { Navigate, Outlet, type RouteObject } from "react-router-dom";
+import { AuthHandler } from "../components/AuthHandler";
 import Layout from "../components/Layout";
 import LastInventory from "../components/inventory/last-inventory/LastInventory";
 import UserSettingsProvider from "../contexts/UserSettingsContext";
@@ -9,9 +10,11 @@ export const routes: RouteObject[] = [
   {
     path: "/",
     element: (
-      <UserSettingsProvider>
-        <Layout />
-      </UserSettingsProvider>
+      <AuthHandler>
+        <UserSettingsProvider>
+          <Layout />
+        </UserSettingsProvider>
+      </AuthHandler>
     ),
     children: [
       {
@@ -56,5 +59,9 @@ export const routes: RouteObject[] = [
   {
     path: "new-account",
     lazy: lazyRoute(() => import("../components/new-account/NewAccount")),
+  },
+  {
+    path: "session-expired",
+    lazy: lazyRoute(() => import("../components/session-expired/SessionExpired")),
   },
 ];


### PR DESCRIPTION
The goal of this PR is to improve the user experience with user sessions.

## Session expired page

As we don't rely on refresh tokens - _yet?_ - the lifetime of the session is the one from the access token.
For example, it is set to 12 hours currently.
It means that if the user remained kept its tab open for longer than that, the session was dead, the user received 401 from the API but the UI behavior was not properly handled.
This PR adds an event listener whenever the access token has expired.
When it happens, the user is redirected on a specific page that explains that the session is expired and that they can reconnect if needed.

This way, we handle user sessions more gracefully and avoid feedback from user about weird behaviors.
We could have redirected directly, but providing no feedback could we confusing for the user.

## Disable automatic silent token renew

It's not enabled on IDP side currently so it fails.
We could still investigate to enable it: see https://zitadel.com/blog/silent-login
The benefit would be to allow sessions longer than 12h that can "abruptly" finish.
It seems to be different than the refresh token flow, which is another possibility.

## Move user session to local storage

That's a debatable one 🔥.
Currently the session is stored with the default config: `sessionStorage`.

In this PR I decided to move it to `localStorage`, which - I know - is not the most recommended way to store session.
See useful docs here https://auth0.com/docs/secure/security-guidance/data-security/token-storage and https://auth0.com/blog/secure-browser-storage-the-facts/

However, compared to the current behavior I believe that it brings benefits worth the slightly worse security risk.
To sum up:

- Both `sessionStorage` and `localStorage` are equally vulnerable to XSS attacks.
- Both share the same `Same Origin` behavior
- The upside of `sessionStorage` is that - at least - the session info is cleared whenever the tab is closed. However, it mainly helps with physical access to the browser to extract it. It does not bring much benefit with XSS.
- However, it also means that the session can not be shared between several tabs, or whenever reopening the tab. That is quite inconvenient.
- On the other hand `localStorage` can persist, so it allows user to reopen their tabs without the need to reconnect, or can easily keep several tabs open. Definitely a far greater UX.

I am aware of the possible security implications, but we have to keep in mind that:
- The safest alternative is to rely on in-memory storage - which cannot be persisted.
- Another safer alternative is to rely on HttpOnly Cookies and so on. So it means that we would need to have our backend acting as a backend for frontend here + implement countermeasures like CSRF. It merely would help to avoid extracting the token, but could not help with a well crafted XSS+CSRF attack anyway.
- We don't use refresh tokens, so an extracted token has a max lifetime of 12h. We could even improve that by reducing the lifetime IF needed.
With that in mind, I think that switching to local storage is an acceptable compromise here.

## Note

This PR also kind of resolves #1250 as we don't expect users to be greeted with the account page as often as before.
If needed, we could also look into `login_hint` on signin ( https://zitadel.com/docs/apis/openidoauth/endpoints ) to skip the account selection. I tried and it works well, however I am not sure it is even worth it for real users.