### PR TITLE
fix(inventory): duration field could be cleared

### DIFF
--- a/packages/frontend/src/features/observation/inventory/inventory-form/InventoryForm.tsx
+++ b/packages/frontend/src/features/observation/inventory/inventory-form/InventoryForm.tsx
@@ -126,7 +126,7 @@ const InventoryForm: FunctionComponent<InventoryFormProps> = ({
 
   const onSubmit: SubmitHandler<InventoryFormState> = (inventoryFormData) => {
     // FIXME assertion is done thanks to zod resolver, however types are not inferred
-    onSubmitForm?.(inventoryFormData as unknown as UpsertInventoryInput);
+    onSubmitForm?.(inventoryFormData as z.infer<typeof upsertInventoryFormInput>);
   };
 
   return (

--- a/packages/frontend/src/features/observation/inventory/inventory-form/InventoryFormDate.tsx
+++ b/packages/frontend/src/features/observation/inventory/inventory-form/InventoryFormDate.tsx
@@ -1,4 +1,3 @@
-import { getMinutesFromTime } from "@ou-ca/common/utils/time-format-convert";
 import { InfoCircle } from "@styled-icons/boxicons-regular";
 import { type FunctionComponent } from "react";
 import { useFormState, type UseFormReturn } from "react-hook-form";
@@ -38,7 +37,7 @@ const InventoryFormDate: FunctionComponent<InventoryFormDateProps> = ({ register
       />
       <TextInput
         {...register("duration", {
-          setValueAs: (v: string | null) => (v?.length ? getMinutesFromTime(v) : null),
+          setValueAs: (v: string | number | null) => (typeof v !== "string" || v.length ? v : null),
         })}
         textInputClassName="w-24 py-1"
         label={


### PR DESCRIPTION
Found out on user's experience:

- From new inventory, set a valid duration
- Select a localities
- Use map to drag pin and use custom coordinates
-> Duration gets cleared

---

The current implementation of the duration field was alwas a bit fragile.
On form side, we enter the duration as a string that represents a number a minute or a time format (e.g. 2:06 or 126)
On API side, only numbers are used.

To use the common input resolver, I used to convert the field duration - usually entered as a string to the number in minutes via `setValueAs`. It seemed to do the job while being a bit ugly.
However here, it looks like dragging the map will trigger an external update - that consequently will rerun into `setValueAs`.
The issue is that at that point, the internal form value has been already transformed to a number, so setting it again would render it null.

So the first change is to avoid that. To do that, we make sure that we map the form value (usually the input) to `null` if and only if the input is an empty string. Otherwise we'll keep it as is.
As a reminder, we do this tweak to make sure that `""` and `null` are similar to detect changes on fields properly.

On top of that, and to make sure that we will send numbers, and always keep the user input as it is - no more `11:11` that bnecomes `671` in the input - we change a bit the resolver to do the following:
- Don't use the duration field as is
- Transform empty string to `null` (although this might be redundant)
- Transform a non-empty string to the number in minutes
- Add a refine so that `null` is OK, and otherwise if it's a number, it has to be a finite one since the transform above could return `NaN`.
